### PR TITLE
Remove "mobile" link in homepage

### DIFF
--- a/app/views/lobby/home.scala
+++ b/app/views/lobby/home.scala
@@ -182,7 +182,7 @@ object home {
           a(href := "/about")(trans.aboutX("Lishogi")),
           a(href := "/faq")(trans.faq.faqAbbreviation()),
           a(href := "/contact")(trans.contact.contact()),
-          a(href := "/mobile")(trans.mobileApp()),
+          //a(href := "/mobile")(trans.mobileApp()),
           a(href := routes.Page.tos())(trans.termsOfService()),
           a(href := routes.Page.privacy())(trans.privacy()),
           a(href := routes.Page.source())(trans.sourceCode()),


### PR DESCRIPTION
This is both a suggestion & a pull request. I personally don't see any use for this link. Unless there's a mobile version currently in development.